### PR TITLE
[Client]/#5/SignUp 컴폰넌트 구현 

### DIFF
--- a/safu-client/src/components/SignUp.js
+++ b/safu-client/src/components/SignUp.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import axios from 'axios';
 import { withRouter } from 'react-router-dom';
+import { fakeUsersData } from './__test__/fakeUsersData';
 
 class SignUp extends React.Component {
   constructor(props) {
@@ -11,17 +12,62 @@ class SignUp extends React.Component {
       password: '',
       passwordCheck: '',
       githubId: '',
+
+      isAvailedEmail: '',
+      isAvailedPassword: '',
+      isAvailedPasswordCheck: '',
     };
   }
   handleSignUpValue = (key) => (e) => {
-    this.setState({ [key]: e.target.value });
+    if (key === 'email') {
+      var emailreg = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
+      var email = e.target.value;
+      if (email.length > 0 && false === emailreg.test(email)) {
+        this.setState({ isAvailedEmail: '올바른 이메일 형식이 아닙니다.' });
+      } else {
+        for (let userInfo of fakeUsersData) {
+          console.log(userInfo);
+          if (userInfo.email === email) {
+            console.log(userInfo.email);
+            this.setState({ isAvailedEmail: '이미 존재하는 email입니다.' });
+            break;
+          } else {
+            this.setState({ isAvailedEmail: '' });
+            this.setState({ [key]: e.target.value });
+          }
+        }
+      }
+    }
+
+    if (key === 'password') {
+      var reg = /^(?=.*?[a-z])(?=.*?[0-9]).{8,}$/;
+      var password = e.target.value;
+      if (password.length > 0 && false === reg.test(password)) {
+        this.setState({
+          isAvailedPassword: '비밀번호는 8자 이상이어야 하며, 숫자/소문자를 모두 포함해야 합니다.',
+        });
+      } else {
+        this.setState({ isAvailedPassword: '' });
+        this.setState({ [key]: e.target.value });
+      }
+    }
+
+    if (key === 'passwordCheck') {
+      var passwordCheck = e.target.value;
+      if (passwordCheck.length > 0 && this.state.password !== passwordCheck) {
+        this.setState({ isAvailedPasswordCheck: '비밀번호가 일치하지 않습니다.' });
+      } else {
+        this.setState({ isAvailedPasswordCheck: '' });
+        this.setState({ [key]: e.target.value });
+      }
+    }
+
+    if (key === 'githubId') {
+      this.setState({ [key]: e.target.value });
+    }
   };
 
   handleLoginButton = () => {
-    // 제출하기(회원가입) 버튼을 누르면 이 event가 발생
-    // 이 버튼은 서버에 회원가입을 요청 후 로그인 페이지로 리다이렉트 해줌
-    // 이미 회원가입이 되어 있는 경우, email 유효성 검사에서 걸러지므로 따로 확인 필요없음.
-    // axios 공식문서 https://xn--xy1bk56a.run/axios/guide/api.html#%EA%B5%AC%EC%84%B1-%EC%98%B5%EC%85%98 에서 //post 요청 전송 을 참고
     axios({
       method: 'post',
       url: 'http://localhost/user/signup',
@@ -33,11 +79,12 @@ class SignUp extends React.Component {
     })
       .then((res) => {
         //200(OK), 201(Created)
-        // history.pushState('/main');
+        console.log('SignUp res: ', res);
+        //history.pushState('/reviews');
       })
       .catch((err) => {
         //500(err)
-        // console.error(err);
+        console.error(err);
       });
   };
 
@@ -50,6 +97,7 @@ class SignUp extends React.Component {
             <label htmlFor="email">
               email
               <input type="email" onChange={this.handleSignUpValue('email').bind(this)}></input>
+              <div>{this.state.isAvailedEmail}</div>
             </label>
           </li>
           <li>
@@ -59,6 +107,7 @@ class SignUp extends React.Component {
                 type="password"
                 onChange={this.handleSignUpValue('password').bind(this)}
               ></input>
+              <div>{this.state.isAvailedPassword}</div>
             </label>
           </li>
           <li>
@@ -68,6 +117,7 @@ class SignUp extends React.Component {
             >
               pw 확인
               <input type="password"></input>
+              <div>{this.state.isAvailedPasswordCheck}</div>
             </label>
           </li>
           <li>

--- a/safu-client/src/components/__test__/fakeUsersData.js
+++ b/safu-client/src/components/__test__/fakeUsersData.js
@@ -1,0 +1,23 @@
+export const fakeUsersData = [
+  {
+    email: 'jhjyj5414@naver.com',
+    password: 'guswjd5414',
+    githubId: 'Gracechung-sw',
+    active: 'True',
+    created_at: '20:30',
+  },
+  {
+    email: 'hjngy0511@gmail.com',
+    password: 'guswjd5414',
+    githubId: 'Gracechung-sw',
+    active: 'True',
+    created_at: '20:31',
+  },
+  {
+    email: 'msh@naver.com',
+    password: 'mshmsh0000',
+    githubId: 'hdaleee',
+    active: 'True',
+    created_at: '20:32',
+  },
+];


### PR DESCRIPTION
**to do 1** - SignUp 컴폰넌트 구현 및 유효성 검사에 따른 안내 메세지 추가
**to do 2** - 이메일은 이메일 형식 을 정규표현식을 이용하여 검사해주었고, 형식 검사가 통과하였을 시, 중복 검사를 진행하게 됩니다. 
비밀 번호는 '8자 이상이어야 하고, 숫자/소문자를 모두 포함해야 한다.'는 조건으로 정규표현식을 이용하여 검사 해줍니다. 

**extra.** 유효성 검사를 위해 fake Users 데이터를 components/__test__/fakeUsersData.js 로 만들었습니다. 

**논의사항)**
**1.** 비밀번호 유효성 검사에 글자수, 숫자, 소문자 외에 더 추가하고 싶으신 것이 있는지 의견 주시면 감사하겠습니다. 
- 하나 이상의 영문 대문자 (?=.*?[AZ])
- 하나 이상의 영문 소문자 (?=.*?[az])
- 하나 이상의 숫자 (?=.*?[0-9])
- 하나 이상의 특수 문자 (?=.*?[#?!@$%^&*-])
- 최소 길이 8자 .{8,} (앵커 포함)
이런 것들을 정규표현식을 통해 검사할 수 있습니다.
**2.** 유효성 검사에 따른 안내문 출력이 smooth하게 출력되었으면 좋겠습니다. CSS로 가능할까요(예를 들어 smooth transition)? @hdaleee 
**3.** GithubID 는 진짜 존재하는 GithubId인가? 를 검사하는 것 말고는 딱히 없다고 생각되어서 하지 않았는데, 혹시 검사해야할 사항 의견 있으신 분 의견 주시면 감사하겠습니다.
