### PR TITLE
[Client]/#37/login redirect

### DIFF
--- a/safu-client/src/__test__/fakeUsersData.js
+++ b/safu-client/src/__test__/fakeUsersData.js
@@ -1,0 +1,23 @@
+export const fakeUsersData = [
+  {
+    useremail: 'jhjyj5414@naver.com',
+    password: 'guswjd5414',
+    githubId: 'Gracechung-sw',
+    active: 'True',
+    created_at: '20:30',
+  },
+  {
+    useremail: 'hjngy0511@gmail.com',
+    password: 'guswjd5414',
+    githubId: 'Gracechung-sw',
+    active: 'True',
+    created_at: '20:31',
+  },
+  {
+    useremail: 'msh@naver.com',
+    password: 'mshmsh0000',
+    githubId: 'hdaleee',
+    active: 'True',
+    created_at: '20:32',
+  },
+];

--- a/safu-client/src/components/SignUp.js
+++ b/safu-client/src/components/SignUp.js
@@ -1,1 +1,152 @@
 //Signup.js - state에 따라 or 라우팅에 따라) 변경되는 부분: x
+
+import React from 'react';
+import axios from 'axios';
+import { withRouter } from 'react-router-dom';
+
+class SignUp extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      useremail: '',
+      password: '',
+      passwordCheck: '',
+      githubId: '',
+      isAvailedEmail: '',
+      isAvailedPassword: '',
+      isAvailedPasswordCheck: '',
+    };
+  }
+  handleSignUpValue = (key) => (e) => {
+    if (key === 'useremail') {
+      var emailreg = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
+      var useremail = e.target.value;
+      this.setState({ [key]: useremail });
+      if (useremail.length > 0 && false === emailreg.test(useremail)) {
+        this.setState({ isAvailedEmail: '올바른 이메일 형식이 아닙니다.' });
+      } else {
+        axios({
+          method: 'post',
+          url: 'http://localhost:4000/users/signup/checkId',
+          data: {
+            useremail: e.target.value,
+          },
+        })
+          .then((res) => {
+            if (res.data !== null) {
+              this.setState({ isAvailedEmail: '이미 존재하는 email입니다.' });
+            } else {
+              this.setState({ isAvailedEmail: '' });
+              this.setState({ [key]: useremail });
+            }
+          })
+          .catch((err) => {
+            console.error(err);
+          });
+      }
+    }
+    if (key === 'password') {
+      var reg = /^(?=.*?[a-z])(?=.*?[0-9]).{8,}$/;
+      var password = e.target.value;
+      if (password.length > 0 && false === reg.test(password)) {
+        this.setState({
+          isAvailedPassword: '비밀번호는 8자 이상이어야 하며, 숫자/소문자를 모두 포함해야 합니다.',
+        });
+      } else {
+        this.setState({ isAvailedPassword: '' });
+        this.setState({ [key]: e.target.value });
+      }
+    }
+    if (key === 'passwordCheck') {
+      var passwordCheck = e.target.value;
+      if (passwordCheck.length > 0 && this.state.password !== passwordCheck) {
+        this.setState({ isAvailedPasswordCheck: '비밀번호가 일치하지 않습니다.' });
+      } else {
+        this.setState({ isAvailedPasswordCheck: '' });
+        this.setState({ [key]: e.target.value });
+      }
+    }
+    if (key === 'githubId') {
+      this.setState({ [key]: e.target.value });
+    }
+  };
+  handleSignUpButton = () => {
+    if (
+      this.state.isAvailedEmail === '' &&
+      this.state.isAvailedPassword === '' &&
+      this.state.isAvailedPasswordCheck === ''
+    ) {
+      axios({
+        method: 'post',
+        url: 'http://localhost:4000/users/signup',
+        data: {
+          useremail: this.state.useremail,
+          password: this.state.password,
+          githubId: this.state.githubId,
+        },
+      })
+        .then((res) => {
+          //200(OK), 201(Created)
+          // this.props.history.push('/users/login');
+          console.log('회원가입 완료');
+        })
+        .catch((err) => {
+          //500(err)
+          console.error(err);
+        });
+    } else {
+      alert('필수조건을 만족해 주셔야 합니다.');
+    }
+  };
+  render() {
+    const { history } = this.props;
+    return (
+      <div>
+        <ul>
+          <li>
+            <label htmlFor="useremail">
+              <div>email</div>
+              <input type="useremail" onChange={this.handleSignUpValue('useremail')}></input>
+              <div>{this.state.isAvailedEmail}</div>
+            </label>
+          </li>
+          <li>
+            <label htmlFor="password">
+              <div>password</div>
+              <input type="password" onChange={this.handleSignUpValue('password')}></input>
+              <div>{this.state.isAvailedPassword}</div>
+            </label>
+          </li>
+          <li>
+            <label htmlFor="password check" onChange={this.handleSignUpValue('passwordCheck')}>
+              <div>password 확인</div>
+              <input type="password"></input>
+              <div>{this.state.isAvailedPasswordCheck}</div>
+            </label>
+          </li>
+          <li>
+            <label htmlFor="Github ID" onChange={this.handleSignUpValue('githubId')}>
+              <div>Github ID (for identification)</div>
+              <input></input>
+            </label>
+          </li>
+        </ul>
+        <div>
+          <button
+            onClick={(e) => {
+              e.preventDefault();
+              {
+                this.handleSignUpButton();
+              }
+            }}
+          >
+            Submit
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+// export default withRouter(SignUp);
+export default SignUp;


### PR DESCRIPTION
지금쯤은 모두들 server와 client PR 받아가셔서

main-> signup-> login-> logged main-> mypage
|-> find id or find pw -> login

이렇게 한 바퀴 돌려보는게 좋을 것 같아 일단 완전히 완성 된 것은 아니지만 PR합니다.

- to do 2 - 회원이 아니신가요? Sign up 버튼 누르면 -> redirect -> Sign up 페이지, 
to do 4 - indPW 버튼 누르면 -> redirect -> find PW 페이지
구현이 남아있습니다. 
이는 fix 브랜치로 추가하겠습니다. 