### PR TITLE
[Client/#5, #40/signup/리다이렉트

### DIFF
--- a/safu-client/src/components/SignUp.js
+++ b/safu-client/src/components/SignUp.js
@@ -87,7 +87,7 @@ class SignUp extends React.Component {
       })
         .then((res) => {
           //200(OK), 201(Created)
-          // this.props.history.push('/users/login');
+          this.props.history.push('/Login');
           console.log('회원가입 완료');
         })
         .catch((err) => {
@@ -118,16 +118,16 @@ class SignUp extends React.Component {
             </label>
           </li>
           <li>
-            <label htmlFor="password check" onChange={this.handleSignUpValue('passwordCheck')}>
+            <label htmlFor="password check">
               <div>password 확인</div>
-              <input type="password"></input>
+              <input type="password" onChange={this.handleSignUpValue('passwordCheck')}></input>
               <div>{this.state.isAvailedPasswordCheck}</div>
             </label>
           </li>
           <li>
-            <label htmlFor="Github ID" onChange={this.handleSignUpValue('githubId')}>
+            <label htmlFor="Github ID">
               <div>Github ID (for identification)</div>
-              <input></input>
+              <input onChange={this.handleSignUpValue('githubId')}></input>
             </label>
           </li>
         </ul>
@@ -148,5 +148,4 @@ class SignUp extends React.Component {
   }
 }
 
-// export default withRouter(SignUp);
-export default SignUp;
+export default withRouter(SignUp);


### PR DESCRIPTION
지금쯤은 모두들 server와 client PR 받아가셔서

main-> signup-> login-> logged main-> mypage
                                 |-> find id or find pw -> login

이렇게 한 바퀴 돌려보는게 좋을 것 같아 일단 완전히 완성 된 것은 아니지만 PR합니다.

signup 후 login 페이지로 redirect 완료
그런데 어떤 경우에는 잘 되고 어떨 때는 리다이렉트가 되어도 isLogin 상태가 바뀌지 않습니다. 
flow가 어딘지 안 맞는 곳이 있는 것 같은데, 발견하면 fix 브랜치로 수정하겠습니다. 
