### PR TITLE
[Client]/#37/login 후 redirect 문제 fix

### DIFF
--- a/safu-client/src/components/Login.js
+++ b/safu-client/src/components/Login.js
@@ -37,9 +37,9 @@ class Login extends React.Component {
       .then((res) => {
         //status 가 200이면,
         this.setState({ isLoginMessage: true });
-        // logged main page로 redirect
-        //this.props.history.push('/'); //
-        res.redirect('/');
+      })
+      .then(() => {
+        window.location = '/';
       })
       .catch((err) => {
         //status가 401이면


### PR DESCRIPTION
log in 버튼 누르면 -> redirect -> (logged) main 페이지
this.props.history.push로 했을 때 리랜더링이 되지 않아서 isLogin 상태가 바뀌지 않는 문제를 해결

