### PR TITLE
[Client]#5/signup/githubId 유효성검사

### DIFF
--- a/safu-client/src/components/SignUp.js
+++ b/safu-client/src/components/SignUp.js
@@ -75,7 +75,8 @@ class SignUp extends React.Component {
     if (
       this.state.isAvailedEmail === '' &&
       this.state.isAvailedPassword === '' &&
-      this.state.isAvailedPasswordCheck === ''
+      this.state.isAvailedPasswordCheck === '' &&
+      this.state.githubId !== ''
     ) {
       axios({
         method: 'post',


### PR DESCRIPTION
githubId의 유효성 검사가 없다고 생각했는데, 생각해보니 null이면 안되므로 이를 검사 해주는게 유효성 검사라고 생각할 수 있다. 
그래서 이것도 빈칸이 아닐 때 그제서야 회원가입이 가능하게 함