### PR TITLE
#14,#17/:art:/mypage와 Edit info 연결, Edit info 기능 정상작동 

### DIFF
--- a/safu-client/src/components/Mypage.js
+++ b/safu-client/src/components/Mypage.js
@@ -8,15 +8,33 @@ import CardList from './CardList';
 class Mypage extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      isLogin: false,
+      userInfo: [],
+    };
+    axios({
+      method: 'get',
+      url: 'http://localhost:4000/users/read',
+    })
+      .then((res) => {
+        if (res.data[1] !== undefined && res.data[1].isLogin === true) {
+          this.setState({ userInfo: res.data[0], isLogin: true });
+        } else {
+          this.setState({ userInfo: res.data });
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   }
   render() {
     return (
       <div>
-        <h2>My Page</h2>
+        {/* <h2>My Page</h2> */}
         <ul>
           <li>
             <p>E-mail</p>
-            {/* <p>{userInfo.email}</p>  API로 받아오면 주석 풀기*/}
+            {/* <p>{userInfo.useremail.email}</p>  API로 받아오면 주석 풀기*/}
           </li>
           <li>
             <p>Github ID</p>
@@ -24,13 +42,37 @@ class Mypage extends React.Component {
           </li>
           <li>
             <div>
-              <button>개인정보수정</button>
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  this.props.history.push({
+                    pathname: '/Infoedit',
+                    userInfo: {
+                      email: 'hjhjhj@naver.com', //여기를 {userInfo.useremail.email} 로 넣어줘야함.
+                      password: 'hjhjhj5414', //여기를 {userInfo.password} 로 넣어줘야함.
+                      githubId: 'hjhjhj', //여기를 {userInfo.githubId} 로 넣어줘야함.
+                    },
+                  });
+                }}
+              >
+                개인정보수정
+              </button>
             </div>
           </li>
         </ul>
         <div>
           <p>카드를 클릭해서 후기를 수정할 수 있습니다.</p>
-          {/* <CardList></CardList> 상현님 CardList랑 합쳐지면 주석 풀기*/}
+          <CardList isLogin={this.state.isLogin} userInfo={this.state.userInfo}></CardList>
+          {/* server에서 이것도 getReviews와 같은 형식으로 [[{},{},{}], {isLogin:}] 과 같은 형식으로 보내준다면 
+          CardList 논의 필요 : isLogin을 true로 해놓으면 mypage에서도 +버튼 나옴, 그러면 문구를 
+          '새로운 후기를 등록하거나 카드를 클릭해서 후기를 수정할 수 있습니다. '
+          라고 바꾸어야하고, 
+          isLogin을 강제로 this.state에서 false로 넣고, 21번째 줄에서 isLogin:true 해주는 것을 없애면
+          +버튼이 보이지 않아서 등록기능은 없고 수정만 가능해짐. 
+          논의사항
+          1. server에서 Get myPage 응답으로 어떤 형식을 보내주실건지
+          2. + 버튼을 있게 할건지 / 없게 할 건지 
+          */}
         </div>
       </div>
     );

--- a/safu-client/src/components/Nav.js
+++ b/safu-client/src/components/Nav.js
@@ -8,7 +8,10 @@ import Mypage from './Mypage';
 import Main from './Main';
 import Findid from './findId';
 import Findpw from './findPw';
+import Infoedit from './infoEdit';
+
 axios.defaults.withCredentials = true;
+
 class Nav extends React.Component {
   // console.log("props :",props);
   // 하위의 li 들은 컴포넌트로 변경예정
@@ -60,6 +63,7 @@ class Nav extends React.Component {
             <Switch>
               <Route path="/" exact component={Main}></Route>
               <Route path="/Mypage" component={Mypage}></Route>
+              <Route path="/Infoedit" component={Infoedit}></Route>
             </Switch>
           </BrowserRouter>
         </div>

--- a/safu-client/src/components/infoEdit.js
+++ b/safu-client/src/components/infoEdit.js
@@ -1,1 +1,118 @@
 //infoEdit.js - state에 따라 or 라우팅에 따라) 변경되는 부분: x
+import React from 'react';
+import axios from 'axios';
+axios.defaults.withCredentials = true;
+class Infoedit extends React.Component {
+  constructor(props) {
+    super(props);
+    const userInfo = props.history.location.userInfo;
+    this.state = {
+      useremail: this.props.history.location.userInfo.email,
+      password: this.props.history.location.userInfo.password,
+      passwordCheck: this.props.history.location.userInfo.password,
+      githubId: this.props.history.location.userInfo.githubId,
+      isAvailedPassword: '',
+      isAvailedPasswordCheck: '',
+    };
+  }
+  handleInfoEditValue = (key) => (e) => {
+    if (key === 'password') {
+      var reg = /^(?=.*?[a-z])(?=.*?[0-9]).{8,}$/;
+      var password = e.target.value;
+      if (password.length > 0 && false === reg.test(password)) {
+        this.setState({
+          isAvailedPassword: '비밀번호는 8자 이상이어야 하며, 숫자/소문자를 모두 포함해야 합니다.',
+        });
+      } else if (password === this.state.passwordCheck) {
+        console.log('password: ', password);
+        this.setState({ isAvailedPassword: '이전 비밀번호와 동일합니다.' });
+      } else {
+        this.setState({ isAvailedPassword: '' });
+        this.setState({ [key]: e.target.value });
+      }
+    }
+    if (key === 'passwordCheck') {
+      var passwordCheck = e.target.value;
+      if (passwordCheck.length > 0 && this.state.password !== passwordCheck) {
+        this.setState({ isAvailedPasswordCheck: '비밀번호가 일치하지 않습니다.' });
+      } else {
+        this.setState({ isAvailedPasswordCheck: '' });
+        this.setState({ [key]: e.target.value });
+      }
+    }
+    if (key === 'githubId') {
+      this.setState({ [key]: e.target.value });
+    }
+  };
+  handleInfoEditButton = () => {
+    if (this.state.isAvailedPassword === '' && this.state.isAvailedPasswordCheck === '') {
+      axios({
+        method: 'post',
+        url: 'http://localhost:4000/users/signup', //회원가입 API로도 잘 작동합니다. 다만 있던 회원정보는 그대로 있고, 새로운 히원정보가 생기는 것과 마찬가지가 됩니다. 즉, 비번을 여기서 수정해줬더라도 예전 비밀번호로도 로그인이 되게 됩니다.
+        data: {
+          useremail: this.state.useremail,
+          password: this.state.password,
+          githubId: this.state.githubId,
+        },
+      })
+        .then((res) => {
+          //200(OK), 201(Created)
+          this.props.history.push('/Mypage');
+          console.log('개인정보수정 완료');
+        })
+        .catch((err) => {
+          //500(err)
+          console.error(err);
+        });
+    } else {
+      alert('수정할 것이 없습니다.');
+    }
+  };
+  render() {
+    return (
+      <div className="signup-div">
+        <ul className="signup-box">
+          <li className="email-box">
+            <label htmlFor="useremail">
+              <div>email</div>
+              <div>{this.state.useremail}</div>
+            </label>
+          </li>
+          <li className="password-box">
+            <label htmlFor="password">
+              <div>password</div>
+              <input type="password" onChange={this.handleInfoEditValue('password')}></input>
+              <div>{this.state.isAvailedPassword}</div>
+            </label>
+          </li>
+          <li className="password-chck-box">
+            <label htmlFor="password check">
+              <div>verify password</div>
+              <input type="password" onChange={this.handleInfoEditValue('passwordCheck')}></input>
+              <div>{this.state.isAvailedPasswordCheck}</div>
+            </label>
+          </li>
+          <li className="github-id-box">
+            <label htmlFor="Github ID">
+              <div>Github ID (for identification)</div>
+              <input onChange={this.handleInfoEditValue('githubId')}></input>
+            </label>
+          </li>
+        </ul>
+        <div>
+          <button
+            onClick={(e) => {
+              e.preventDefault();
+              {
+                this.handleInfoEditButton();
+              }
+            }}
+          >
+            Submit
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+export default Infoedit;


### PR DESCRIPTION
‼️ 머지하지 말아주세요!! 다같이 코드를 보며 논의하고 싶은 사항이 있어 PR한 것입니다. 논의가 끝나면 close할 계획입니다. ‼️❣️

**한 것**
#17 editInfo to do 1 - editinfo 컴포넌트 구현
#14 mypage to do 3 -  개인정보수정 버튼 클릭시 -> Editinfo로 리다이렉트 w/t info edit 컴포넌트로 회원 정보 props 전달.
어떻게 전달하면 되는지 알게됨. 일단 get Mypage API 구현이 되기 전이라 하드코딩 해놓았습니다.
#17 editInfo to do 2 - 개인정보수정하기 -> redirect -> mypage 페이지

**개인 정보 수정시 ,**
1) password와 githubID 둘 중 하나만 변경하고 싶을 수도 있으므로 일단 constructor에서 default값으로 원래 사용자의 정보를 넣어두었습니다. 그래서 수정칸에 입력없이 수정하기를 클릭하면 그냥 원래 정보로 남아있습니다.

2) 비밀번호를 수정하려 할 때, 기존의 비밀번호와 동일하면 동일하다는 메세지를 출력하여서 수정을 거부합니다.

3) ~~일단 회원가입과 동일한 개념이라 signup API를 사용했고, 회원가입 API로도 잘 작동합니다. 다만 signup API의 sequelize 메소드를 단순 create에서 FindorCreate를 사용하는 것으로 변경해야한다는 점이 있습니다. Create로만 했을 시, 수정 전 회원정보는 그대로 있고, 새로운 회원정보가 생기는 것과 마찬가지가 되기 때문입니다. 즉, 비번을 여기서 수정해줬더라도 예전 비밀번호로도 로그인이 되게 됩니다. ._@hyunju-song @kimsoolB아니면 새로운 API가 필요합니다.~~
**개인 정보 수정시 조건 더 걸어줬으면 하는 것과 API관련해서 논의했으면 좋겠습니다 ㅎㅎ**

**CSS관련**
@hdaleee  
Figma를 보니 회원가입과 동일한 디자인에 회원탈퇴 버튼 추가 + 이메일은 입력창 없이 그냥 랜더링
만 다른 것 같아 일단 회원가입에서 쓰인 CSS를 그대로 적용하였습니다. 제가 상현님의 CSS을 방해한 것은 아니겠죠?!!ㅠ
<img width="711" alt="스크린샷 2020-10-26 오후 3 39 52 1" src="https://user-images.githubusercontent.com/55108539/97141549-47b33600-17a2-11eb-975b-d98371089edd.png">
