### PR TITLE
[Client]/new Card/카드 생성 후 redirect 

### DIFF
--- a/safu-client/src/components/CardWrite.js
+++ b/safu-client/src/components/CardWrite.js
@@ -29,10 +29,15 @@ class CardWrite extends React.Component {
         <form
           onSubmit={(e) => {
             e.preventDefault();
-            axios.post('http://localhost:4000/review/create', this.state).catch((err) => {
-              alert('failed to create');
-              console.log(err);
-            });
+            axios
+              .post('http://localhost:4000/reviews/create', this.state)
+              .then((res) => {
+                window.location = '/';
+              })
+              .catch((err) => {
+                alert('failed to create');
+                console.log(err);
+              });
           }}
         >
           <div className="card-write">


### PR DESCRIPTION
카드 생성후 (로그인 된) main 페이지로 리다이렉트 추가
서버의 post createReviews와 통신확인 완료

**문제점** 
1. 
![image](https://user-images.githubusercontent.com/55108539/97550049-7fc1af80-1a14-11eb-8f67-3e87982d693a.png)
카드 생성 후 + 버튼 위치가 바뀝니다 (기능은 잘 작동합니다. )

2.  +버튼을 누른 후 (기존 카드는 약간 fade out 되고 그 위해 newCard가 나타납니다. (newCard 기능은 정상 작동) , 그러나 여기서 새로고침을 한 번 하면 기존의 component들은 다 날라가고 newCard 컴포넌트만 남아있습니다. (역시 newCard 기능은 정상 작동)
라우팅 문제인지 CSS로 인한 문제인지는 잘 모르겠습니다. 
![image](https://user-images.githubusercontent.com/55108539/97550762-68cf8d00-1a15-11eb-953a-565ceab56e41.png)
여기서 새로고침 하면 =>  
![image](https://user-images.githubusercontent.com/55108539/97550779-6f5e0480-1a15-11eb-9724-cb83e25299d5.png)

**아주 좋았고 배우고 싶은 것**
1. 
![image](https://user-images.githubusercontent.com/55108539/97550898-9c121c00-1a15-11eb-9a08-f7ead2c34bb7.png)
상현님 이거 경고문구 어떻게 하신 거세요?? 회원가입때도 이렇게 하면 좋을 것 같아서 배우고 싶습니다!
2. 
여기서는 등록 시 enter키가 먹네요?! 혹시 form 태그를 사용해서 그런건가요?? 제가 구현한 컴포넌트들에는 무조건 마우스로 클릭을 해주어야하는데, enter키가 작동되면 훨씬 편할 것 같습니다. 
