### PR TITLE
[Client]fix/HardCoding->GetAPI후map, 데이터 null인 경우 분기

### DIFF
--- a/safu-client/src/components/CardEdit.js
+++ b/safu-client/src/components/CardEdit.js
@@ -12,11 +12,12 @@ function CardEdit(card) {
   const [recommend, setrecommend] = useState(card.card.recommend);
   const [comment, setcomment] = useState(card.card.comment);
   const [bootcampname_before, setBootcampnameBefore] = useState(bootcampname);
+  const [bootcamplist, setbootcamplist] = useState([]);
 
   useEffect(() => {
     axios({
       method: 'post',
-      url: 'http://localhost:4000//reviews/edit',
+      url: 'http://localhost:4000/reviews/edit',
       data: {
         comment: comment,
         bootcampname: bootcampname,
@@ -30,6 +31,20 @@ function CardEdit(card) {
     }).then((req) => {
       console.log(req.data);
     });
+  }, []);
+
+  useEffect(() => {
+    axios({
+      method: 'get',
+      url: 'http://localhost:4000/bootcamplists',
+    })
+      .then((datas) => {
+        const map1 = datas.data.map((x) => x.name);
+        setbootcamplist(map1);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   }, []);
 
   return (
@@ -47,26 +62,14 @@ function CardEdit(card) {
               <option value="" disabled>
                 부트 캠프 선택
               </option>
-              {bootcampname === 'Code States' ? (
-                <option value="Code States" selected>
-                  Code States
-                </option>
-              ) : (
-                <option value="Code States">Code States</option>
-              )}
-              {bootcampname === 'Fast Campus' ? (
-                <option value="Fast Campus" selected>
-                  Fast Campus
-                </option>
-              ) : (
-                <option value="Fast Campus">Fast Campus</option>
-              )}
-              {bootcampname === 'Vanilla Coding' ? (
-                <option value="Vanilla Coding" selected>
-                  Vanilla Coding
-                </option>
-              ) : (
-                <option value="Vanilla Coding">Vanilla Coding</option>
+              {bootcamplist.map((bootcamp) =>
+                bootcampname === bootcamp ? (
+                  <option value={bootcamp} selected>
+                    {bootcamp}
+                  </option>
+                ) : (
+                  <option value={bootcamp}>{bootcamp}</option>
+                ),
               )}
             </select>
           </li>

--- a/safu-client/src/components/CardList.js
+++ b/safu-client/src/components/CardList.js
@@ -39,21 +39,21 @@ class CardList extends React.Component {
               </Link>
             </div>
           </div>
-          {this.props.userInfo.map((card) => (
-            <Card key={card.id} card={card} />
-          ))}
+          {this.props.userInfo.length !== 0
+            ? this.props.userInfo.map((card) => <Card key={card.id} card={card} />)
+            : null}
           <div className="fontType-logo"></div>
         </div>
       );
     } else {
-      return (
+      return this.props.userInfo.length !== 0 ? (
         <div className="card-list">
           {this.props.userInfo.map((card) => (
             <Card key={card.id} card={card} />
           ))}
           <div className="fontType-logo"></div>
         </div>
-      );
+      ) : null;
     }
   }
 }

--- a/safu-client/src/components/CardWrite.js
+++ b/safu-client/src/components/CardWrite.js
@@ -16,8 +16,20 @@ class CardWrite extends React.Component {
       price: '10만원 이하',
       curriculum: '불만족',
       recommend: '비추천',
+      bootcamplist: [],
     };
     this.handleInputValue = this.handleInputValue.bind(this);
+    axios({
+      method: 'get',
+      url: 'http://localhost:4000/bootcamplists',
+    })
+      .then((datas) => {
+        const map1 = datas.data.map((x) => x.name);
+        this.setState({ bootcamplist: map1 });
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   }
 
   handleInputValue = (key) => (e) => {
@@ -49,9 +61,9 @@ class CardWrite extends React.Component {
                   <option value="" disabled defaultValue>
                     부트 캠프 선택
                   </option>
-                  <option value="Code States">Code States</option>
-                  <option value="Fast Campus">Fast Campus</option>
-                  <option value="Vanilla Coding">Vanilla Coding</option>
+                  {this.state.bootcamplist.map((bootcamp) => (
+                    <option value={bootcamp}>{bootcamp}</option>
+                  ))}
                 </select>
               </li>
               <li>


### PR DESCRIPTION
1. CardEdit, CardWrite: 부트 캠프 선택 하드코딩 되어있던 부분 GET Bootcamp list 으로 불러와 mapping해주는 것으로 변경
<img width="1440" alt="스크린샷 2020-11-03 오전 9 03 32" src="https://user-images.githubusercontent.com/55108539/97933235-7722fd80-1db5-11eb-8989-f756e93774f7.png">

@hdaleee 하드코딩 되어있던 부트캠프들 이외에는 배경 색이 부여되지 않는 것 같습니다 ㅎㅎ 시간 되실때 반영 부탁드립니다.

2. CardList: 리뷰 데이터가 하나도 없는 경우 null을 랜더링하도록 조건문으로 분기

